### PR TITLE
feat: PubSubSchemaSerDe accepts schemaRevisionId to get specific revision

### DIFF
--- a/flink_connectors/pubsub/src/main/scala/ai/chronon/flink_connectors/pubsub/PubSubSchemaSerDe.scala
+++ b/flink_connectors/pubsub/src/main/scala/ai/chronon/flink_connectors/pubsub/PubSubSchemaSerDe.scala
@@ -5,17 +5,22 @@ import ai.chronon.online.TopicInfo
 import ai.chronon.online.serde.{AvroCodec, AvroSerDe, Mutation, ProtobufSerDe, SerDe}
 import com.google.api.gax.rpc.NotFoundException
 import com.google.cloud.pubsub.v1.SchemaServiceClient
+import com.google.pubsub.v1.ListSchemaRevisionsRequest;
 import com.google.pubsub.v1.SchemaName
+import com.google.pubsub.v1.SchemaView;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema
+
+import scala.jdk.CollectionConverters._
 
 /** SerDe that fetches schemas from GCP Pub/Sub Schema Registry and auto-detects the format (Avro or Protobuf).
   *
   * Configure via topic string:
-  *   pubsub://topic-name/serde=pubsub_schema/project=my-project/schemaId=my-schema/[proto3_default_as_null=false]
+  *   pubsub://topic-name/serde=pubsub_schema/project=my-project/schemaId=my-schema/[schemaRevisionId=revision-id]/[proto3_default_as_null=false]
   *
   * Parameters:
   *   - project: GCP project name (required)
   *   - schemaId: Schema ID in Pub/Sub Schema Registry (required)
+  *   - schemaRevisionId: Specific schema revision ID to use (optional). If omitted, uses the latest revision.
   *   - proto3_default_as_null: For protobuf schemas, treat proto3 default values as null (optional, defaults to false)
   */
 class PubSubSchemaSerDe(topicInfo: TopicInfo) extends SerDe {
@@ -34,15 +39,26 @@ class PubSubSchemaSerDe(topicInfo: TopicInfo) extends SerDe {
     val schemaClient = buildPubsubSchemaClient()
     val projectName = topicInfo.params.getOrElse(ProjectKey, throw new IllegalArgumentException(s"$ProjectKey not set"))
     val schemaId = topicInfo.params.getOrElse(SchemaIdKey, throw new IllegalArgumentException(s"$SchemaIdKey not set"))
+    val schemaRevisionId = topicInfo.params.get(SchemaRevisionIdKey)
     val schemaName = SchemaName.of(projectName, schemaId)
+
     val schema =
       try {
-        schemaClient.getSchema(schemaName)
+        schemaRevisionId match {
+          case Some(revisionId) => fetchSchemaRevision(schemaClient, schemaName, revisionId)
+          case None             => schemaClient.getSchema(schemaName)
+        }
       } catch {
         case e: NotFoundException =>
-          throw new IllegalArgumentException(s"Schema not found - project: $projectName, schemaId: $schemaId", e)
+          val revisionStr = schemaRevisionId.map(rid => s", revisionId: $rid").getOrElse("")
+          throw new IllegalArgumentException(
+            s"Schema not found - project: $projectName, schemaId: $schemaId$revisionStr",
+            e)
         case e: Exception =>
-          throw new IllegalStateException(s"Failed retrieving schema - project: $projectName, schemaId: $schemaId", e)
+          val revisionStr = schemaRevisionId.map(rid => s", revisionId: $rid").getOrElse("")
+          throw new IllegalStateException(
+            s"Failed retrieving schema - project: $projectName, schemaId: $schemaId$revisionStr",
+            e)
       } finally {
         schemaClient.close()
       }
@@ -61,6 +77,22 @@ class PubSubSchemaSerDe(topicInfo: TopicInfo) extends SerDe {
     }
   }
 
+  private def fetchSchemaRevision(schemaClient: SchemaServiceClient,
+                                  schemaName: SchemaName,
+                                  revisionId: String): com.google.pubsub.v1.Schema = {
+    val request = ListSchemaRevisionsRequest
+      .newBuilder()
+      .setName(schemaName.toString())
+      .setView(SchemaView.FULL)
+      .setPageSize(2)
+      .build();
+    val response = schemaClient.listSchemaRevisions(request)
+    val revisions = response.iteratePages().iterator().next().getValues().asScala
+    revisions.find(_.getRevisionId == revisionId).getOrElse {
+      throw new NotFoundException(new IllegalArgumentException(s"Schema revision not found: $revisionId"), null, false)
+    }
+  }
+
   override def schema: StructType = delegate.schema
 
   override def fromBytes(bytes: Array[Byte]): Mutation = delegate.fromBytes(bytes)
@@ -69,5 +101,6 @@ class PubSubSchemaSerDe(topicInfo: TopicInfo) extends SerDe {
 object PubSubSchemaSerDe {
   val ProjectKey = "project"
   val SchemaIdKey = "schemaId"
+  val SchemaRevisionIdKey = "schemaRevisionId"
   val Proto3DefaultAsNullKey = "proto3_default_as_null"
 }

--- a/flink_connectors/pubsub/src/test/scala/ai/chronon/flink_connectors/pubsub/PubSubSchemaSerDeSpec.scala
+++ b/flink_connectors/pubsub/src/test/scala/ai/chronon/flink_connectors/pubsub/PubSubSchemaSerDeSpec.scala
@@ -5,7 +5,7 @@ import ai.chronon.online.TopicInfo
 import com.google.api.gax.rpc.{NotFoundException, StatusCode}
 import com.google.cloud.pubsub.v1.SchemaServiceClient
 import com.google.protobuf.DynamicMessage
-import com.google.pubsub.v1.{Schema, SchemaName}
+import com.google.pubsub.v1.{ListSchemaRevisionsRequest, Schema, SchemaName}
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema
 import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.any
@@ -161,6 +161,51 @@ class PubSubSchemaSerDeSpec extends AnyFlatSpec {
     val mutationWithoutNull = serDeWithoutNull.fromBytes(emptyMessage.toByteArray)
     assert(mutationWithoutNull.after(0) == "")
     assert(mutationWithoutNull.after(1) == 0)
+  }
+
+  // ============== Schema Revision Tests ==============
+
+  it should "succeed when fetching a specific AVRO schema revision" in {
+    val avroSchemaStr =
+      """{ "type": "record", "name": "test1", "fields": [ { "type": "string", "name": "field1" } ]}"""
+    val revisionId = "abc123"
+    val topicInfo = TopicInfo("test-topic", "pubsub",
+      Map(
+        PubSubSchemaSerDe.ProjectKey -> "test-project",
+        PubSubSchemaSerDe.SchemaIdKey -> "test-schema",
+        PubSubSchemaSerDe.SchemaRevisionIdKey -> revisionId
+      ))
+    val schema = Schema.newBuilder()
+      .setName("test-schema")
+      .setRevisionId(revisionId)
+      .setType(Schema.Type.AVRO)
+      .setDefinition(avroSchemaStr)
+      .build()
+    val mockedSchemaClient = org.mockito.Mockito.mock(classOf[SchemaServiceClient], org.mockito.Mockito.RETURNS_DEEP_STUBS)
+    when(mockedSchemaClient.listSchemaRevisions(any[ListSchemaRevisionsRequest]())
+      .iteratePages().iterator().next().getValues())
+      .thenReturn(java.util.Collections.singletonList(schema))
+
+    val serDe = new MockPubSubSchemaSerDe(topicInfo, mockedSchemaClient)
+    assert(serDe.schema != null)
+  }
+
+  it should "fail when the specified AVRO schema revision is not found" in {
+    val topicInfo = TopicInfo("test-topic", "pubsub",
+      Map(
+        PubSubSchemaSerDe.ProjectKey -> "test-project",
+        PubSubSchemaSerDe.SchemaIdKey -> "test-schema",
+        PubSubSchemaSerDe.SchemaRevisionIdKey -> "nonexistent-revision"
+      ))
+    val statusCode = mock[StatusCode]
+    val mockedSchemaClient = org.mockito.Mockito.mock(classOf[SchemaServiceClient], org.mockito.Mockito.RETURNS_DEEP_STUBS)
+    when(mockedSchemaClient.listSchemaRevisions(any[ListSchemaRevisionsRequest]()))
+      .thenThrow(new NotFoundException(new IllegalArgumentException(), statusCode, true))
+
+    val serDe = new MockPubSubSchemaSerDe(topicInfo, mockedSchemaClient)
+    assertThrows[IllegalArgumentException] {
+      serDe.schema
+    }
   }
 
   // ============== Proto2 Tests ==============


### PR DESCRIPTION
## Summary

Current implementation gets only latest revision from schema.
This complicates schema evolution because Avro format can parse messages with extra data when schema expects less data, but can't parse messages with less data when schema expects more data.

New parameter `schemaRevisionId` is optional. If not sent, default behavior is to get latest revision as happens today.

For this, we are enabling support of getting specific schema revision so that we can freeze schema until publisher starts sending messages with the new fields.

## Testing

* Tested compiling and uploading version to [GCP bucket](https://console.cloud.google.com/storage/browser/zipline-artifacts-sardine-dev/release/0.1.0%2Bdev.lucasmantovani?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=indigo-computer-272415) and refreshing Flink job from local Airflow for specific group by.
* Verified Flink job started successfully and presented no execution error logs: https://console.cloud.google.com/dataproc/jobs/c6301e75-0be2-47b2-85cb-024fcaaec3c6/monitoring?region=us-central1&project=indigo-computer-272415
* Executed `TestBuildUserAggregationsEnv` test and verified data was updated.

## Checklist
- [X] Added Unit Tests
- [ ] Covered by existing CI
- [X] Integration tested
- [ ] Documentation update

