### PR TITLE
feat: streaming in aws improvements [no QA]

### DIFF
--- a/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
+++ b/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
@@ -137,6 +137,19 @@ class K8sFlinkSubmitter(
   def buildFlinkConfiguration(flinkCheckpointUri: String, jobProperties: Map[String, String]): Map[String, String] = {
     val tier = parseTmMemoryTier(jobProperties)
 
+    // K8s HA opt-in: when callers supply `high-availability.storageDir` via jobProperties,
+    // enable Flink Kubernetes HA so JM restarts (node disruption, AMI rolls, EKS upgrades)
+    // reuse BlobKey identity from persistent storage instead of generating new random nonces
+    // — which is the root cause of `IllegalStateException: The library registration
+    // references a different set of library BLOBs` after a JM is rescheduled mid-job.
+    // Without storageDir, no HA keys are injected and existing behavior is preserved exactly.
+    // The companion `kubernetes.cluster-id` is set in `submit()` (where deploymentName exists).
+    val haConfig: Map[String, String] =
+      if (jobProperties.contains("high-availability.storageDir"))
+        Map("high-availability.type" -> "kubernetes")
+      else
+        Map.empty
+
     // extraFlinkConfig (cloud-specific, e.g. IRSA credentials) merged after base;
     // jobProperties applied last so callers can override anything.
     // All jars are available via FLINK_CLASSPATH=/opt/flink/usrlib/*,
@@ -151,7 +164,7 @@ class K8sFlinkSubmitter(
       "state.checkpoint-storage" -> "filesystem",
       "rest.profiling.enabled" -> "true",
       "state.checkpoints.num-retained" -> MaxRetainedCheckpoints
-    ) ++ flinkMemoryConfig(tier) ++ resolvedExtraFlinkConfig ++ jobProperties
+    ) ++ flinkMemoryConfig(tier) ++ resolvedExtraFlinkConfig ++ haConfig ++ jobProperties
   }
 
   private def flinkDeploymentCrdContext: CustomResourceDefinitionContext =
@@ -365,10 +378,17 @@ class K8sFlinkSubmitter(
     // Operator validates parallelism > 0; actual job-level parallelism is set inside the Flink job itself
     job.put("parallelism", Integer.valueOf(1))
     job.put("state", "running")
+    val haEnabled = flinkConfiguration.contains("high-availability.storageDir")
     maybeSavepointUri match {
       case Some(savepointUri) =>
         job.put("upgradeMode", "savepoint")
         job.put("initialSavepointPath", savepointUri)
+      case None if haEnabled =>
+        // HA: last-state resumes from the latest completed checkpoint via the HA
+        // ConfigMaps, preserving BlobKey identity across JM restarts. Survives node
+        // disruptions cleanly — no more "library registration references a different
+        // set of library BLOBs" failures on rescheduled pods.
+        job.put("upgradeMode", "last-state")
       case None =>
         // stateless allows cold restarts without HA; last-state requires HA to be enabled
         job.put("upgradeMode", "stateless")

--- a/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
+++ b/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
@@ -323,6 +323,13 @@ class K8sFlinkSubmitter(
     val tmPodMemory = flinkConfiguration.getOrElse("taskmanager.memory.process.size", "4G")
     val jmPodMemory = flinkConfiguration.getOrElse("jobmanager.memory.process.size", "4G")
 
+    val effectiveTaskSlots = flinkConfiguration
+      .get("taskmanager.numberOfTaskSlots")
+      .map(_.toInt)
+      .getOrElse(tier.taskSlots)
+    val cpuPerSlot: Double = 1.0
+    val tmPodCpu = effectiveTaskSlots * cpuPerSlot
+
     spec.put(
       "jobManager",
       buildComponentSpec(
@@ -340,7 +347,7 @@ class K8sFlinkSubmitter(
       "taskManager",
       buildComponentSpec(
         memory = tmPodMemory,
-        cpu = tier.taskSlots.toDouble,
+        cpu = tmPodCpu,
         replicas = None,
         containerSpec.initContainers,
         allEnvVars,


### PR DESCRIPTION
## Summary

- Tweak the EKS CPU requests for Flink nodes

Currently, the Flink CPU request rely strictly on the tier that the job lands. When doing custom job properties, the CPU request is always 1.

- Enable high availability nodes

When Flink pods restart, we often get this error:

```
java.lang.IllegalStateException: The library registration references a
different set of library BLOBs than previous registrations for this job:
old:[p-...-7e9fe0f33eac9a4c6358e354be39e7d2]
new:[p-...-5d4b15df0d42b5b7c33f4977e4362d54]
```

By setting HA, Flink K8s persists BlobKey identity and JobGraph metadata to S3, so JM/TM pod restarts recover the running job transparently instead of dying with a BlobKey-conflict error.


## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

