### PR TITLE
feat: consider taskmanager.numberOfTaskSlots when setting Flink's CPU request

### DIFF
--- a/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
+++ b/cloud_k8s/src/main/scala/ai/chronon/integrations/cloud_k8s/K8sFlinkSubmitter.scala
@@ -323,6 +323,13 @@ class K8sFlinkSubmitter(
     val tmPodMemory = flinkConfiguration.getOrElse("taskmanager.memory.process.size", "4G")
     val jmPodMemory = flinkConfiguration.getOrElse("jobmanager.memory.process.size", "4G")
 
+    val effectiveTaskSlots = flinkConfiguration
+      .get("taskmanager.numberOfTaskSlots")
+      .map(_.toInt)
+      .getOrElse(tier.taskSlots)
+    val cpuPerSlot: Double = 1.0
+    val tmPodCpu = effectiveTaskSlots * cpuPerSlot
+
     spec.put(
       "jobManager",
       buildComponentSpec(
@@ -340,7 +347,7 @@ class K8sFlinkSubmitter(
       "taskManager",
       buildComponentSpec(
         memory = tmPodMemory,
-        cpu = tier.taskSlots.toDouble,
+        cpu = tmPodCpu,
         replicas = None,
         containerSpec.initContainers,
         allEnvVars,


### PR DESCRIPTION
## Summary

- Tweak the EKS CPU requests for Flink nodes

Currently, the Flink CPU request rely strictly on the tier that the job lands. When doing custom job properties, the CPU request is always 1.

## Checklist
- [ ] Added Unit Tests
- [ ] Covered by existing CI
- [ ] Integration tested
- [ ] Documentation update

